### PR TITLE
Remove extra -lcrypto flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ EXE = ${OBJ}/bin
 COMMIT := $(shell git log -1 --pretty=format:"%H")
 
 CFLAGS = -m64 -O3 -std=gnu11 -Wall -mpclmul -march=core2 -mfpmath=sse -mssse3 -fno-strict-aliasing -fno-strict-overflow -fwrapv -DAES=1 -DCOMMIT=\"${COMMIT}\" -D_GNU_SOURCE=1 -D_FILE_OFFSET_BITS=64
-LDFLAGS = -m64 -ggdb -rdynamic -lm -lrt -lcrypto -lz -lpthread -lcrypto
+LDFLAGS = -m64 -ggdb -rdynamic -lm -lrt -lcrypto -lz -lpthread
 
 LIB = ${OBJ}/lib
 CINCLUDE = -iquote common -iquote .


### PR DESCRIPTION
There were 2 `-lcrypto` flags in `LDFLAGS` section, one of which is obviously redundant.