### PR TITLE
Issue #2: Add support for private network ranges from RFC 1918

### DIFF
--- a/engine/engine.c
+++ b/engine/engine.c
@@ -227,7 +227,7 @@ void engine_init (const char *const pwd_filename, int do_not_open_port) {
 
   if (E->settings_addr.s_addr) {
     ipv4 = ntohl (E->settings_addr.s_addr);
-    if ((ipv4 >> 24) != 10) {
+    if (ipv4_address_is_private(ipv4) <= 0) {
       kprintf ("Bad binded IP address " IP_PRINT_STR ", search in ifconfig\n", IP_TO_PRINT (ipv4));
       ipv4 = 0;
     }

--- a/net/net-connections.c
+++ b/net/net-connections.c
@@ -2178,3 +2178,28 @@ unsigned nat_translate_ip (unsigned local_ip) {
   }
   return local_ip;
 }
+
+int ipv4_address_is_private(unsigned int ipv4) {
+  int ipv4_part1 = ipv4 >> 24 & 255;
+  int ipv4_part2 = ipv4 >> 16 & 255;
+
+  // RFC 1918
+  // check private address range 
+  // 10.0.0.0 - 10.255.255.255
+  if (ipv4_part1 == 10) {
+    return 1;
+  }
+
+  // 172.16.0.0 - 172.31.255.255
+  if (ipv4_part1 == 172 && ipv4_part2 >= 16 && ipv4_part2 <= 31) {
+    return 2;
+  }
+
+  // 192.168.0.0 - 192.168.255.255
+  if (ipv4_part1 == 192 && ipv4_part2 == 168) {
+    return 3;
+  }
+
+  // The address is not in private
+  return 0;
+}

--- a/net/net-connections.h
+++ b/net/net-connections.h
@@ -418,6 +418,14 @@ int get_cur_conn_generation (void);
 void tcp_set_max_accept_rate (int rate);
 void tcp_set_max_connections (int maxconn);
 
+/**
+ * Checks if the given address is in private range according to RFC 1918.
+ * @param ipv4 an integer ipv4 address (like ntohl() returns)
+ * @return a positive value 1-3 defining which subnet is it or a zero
+ *  if the address is not in private range.
+ */
+int ipv4_address_is_private(unsigned int ipv4);
+
 extern int max_special_connections, active_special_connections;
 
 #define MAX_NAT_INFO_RULES	16


### PR DESCRIPTION
+ added check for all RFC 1918 described private ranges while binding using --address argument

Check the issue here https://github.com/TelegramMessenger/MTProxy/issues/2