### PR TITLE
Added vim-common dependency for CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ apt install git curl build-essential libssl-dev zlib1g-dev
 ```
 On CentOS/RHEL:
 ```bash
-yum install openssl-devel zlib-devel
+yum install openssl-devel zlib-devel vim-common
 yum groupinstall "Development Tools"
 ```
 


### PR DESCRIPTION
There's no `xxd` utility on CentOS (haven't checked RHEL), which is required to generate secret for MTProxy, but it can be found in `vim-common` package.

```
[me@me]# yum whatprovides '*bin/xxd'

Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
(mirrors here)
2:vim-common-7.4.160-4.el7.x86_64 : The common files needed by any version of
                                  : the VIM editor
Repo        : base
Matched from:
Filename    : /usr/bin/xxd
```