### PR TITLE
Why did you smartest guys thought PID will never go beyond 65535?

### DIFF
--- a/common/pid.c
+++ b/common/pid.c
@@ -39,7 +39,6 @@ npid_t PID;
 void init_common_PID (void) {
   if (!PID.pid) {
     int p = getpid ();
-    assert (!(p & 0xffff0000));
     PID.pid = p;
   }
   if (!PID.utime) {

--- a/common/pid.h
+++ b/common/pid.h
@@ -24,19 +24,21 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #pragma pack(push,4)
 
 struct process_id {
   unsigned ip;
   short port;
-  unsigned short pid;
+  uint32_t pid;
   int utime;
 };
 
 struct process_id_ext {
   unsigned ip;
   short port;
-  unsigned short pid;
+  uint32_t pid;
   int utime;
   int actor_id;
 };


### PR DESCRIPTION
```
~/src/MTProxy$ objs/bin/mtproto-proxy --port 30011 --http-ports 30010 --mtproto-secret `cat /etc/telegram/key` --aes-pwd /etc/telegram/proxy-secret /etc/telegram/proxy-multi.conf --slaves 0
[99611][2019-04-16 10:21:50.337621 local] Invoking engine mtproxy-0.01 compiled at Apr 16 2019 10:21:28 by gcc 6.3.0 20170516 64-bit after commit 2c942119c4ee340c80922ba11d14fb3b10d5e654
[99611][2019-04-16 10:21:50.337783 local] config_filename = '/etc/telegram/proxy-multi.conf'
mtproto-proxy: common/pid.c:42: init_common_PID: Assertion `!(p & 0xffff0000)' failed.
[pid 99611] [time 1555381310] 
------- Stack Backtrace -------
objs/bin/mtproto-proxy(print_backtrace+0x16)[0x55956e7b1986]
objs/bin/mtproto-proxy(extended_debug_handler+0x10)[0x55956e7b1ac0]
/lib/x86_64-linux-gnu/libpthread.so.0(+0x110c0)[0x7fa72acb50c0]
/lib/x86_64-linux-gnu/libc.so.6(gsignal+0xcf)[0x7fa72a937fff]
/lib/x86_64-linux-gnu/libc.so.6(abort+0x16a)[0x7fa72a93942a]
/lib/x86_64-linux-gnu/libc.so.6(+0x2be67)[0x7fa72a930e67]
/lib/x86_64-linux-gnu/libc.so.6(+0x2bf12)[0x7fa72a930f12]
objs/bin/mtproto-proxy(+0x4f881)[0x55956e7b5881]
objs/bin/mtproto-proxy(engine_init+0xc5)[0x55956e7ac0f5]
objs/bin/mtproto-proxy(default_main+0x113)[0x55956e7acf23]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf1)[0x7fa72a9252e1]
objs/bin/mtproto-proxy(_start+0x2a)[0x55956e7771fa]
[pid 99611] [time 1555381310] -------------------------------
[pid 99611] [time 1555381310] mtproxy-0.01 compiled at Apr 16 2019 10:21:28 by gcc 6.3.0 20170516 64-bit after commit 2c942119c4ee340c80922ba11d14fb3b10d5e654[pid 99611] [time 1555381310] 
~/src/MTProxy$ echo $$
81942
```