### PR TITLE
Fix to build with GCC 10

### DIFF
--- a/common/resolver.h
+++ b/common/resolver.h
@@ -27,7 +27,7 @@
 extern "C" {
 #endif
 
-int kdb_hosts_loaded;
+extern int kdb_hosts_loaded;
 int kdb_load_hosts (void);
 
 struct hostent *kdb_gethostbyname (const char *name);

--- a/mtproto/mtproto-proxy.c
+++ b/mtproto/mtproto-proxy.c
@@ -409,7 +409,7 @@ int worker_id, workers, slave_mode, parent_pid;
 int pids[MAX_WORKERS];
 
 long long get_queries;
-long long http_queries;
+extern long long http_queries;
 int pending_http_queries;
 
 long long active_rpcs, active_rpcs_created;

--- a/net/net-stats.c
+++ b/net/net-stats.c
@@ -52,7 +52,7 @@
 
 #include "engine/engine.h"
 
-struct process_id PID;
+extern struct process_id PID;
 
 extern int zheap_debug;
 long long queries_allocated;

--- a/vv/vv-tree.c
+++ b/vv/vv-tree.c
@@ -21,7 +21,7 @@
 
 #include <assert.h>
       
-long long total_vv_tree_nodes;
+extern long long total_vv_tree_nodes;
 
 #define SUFFIX2(a,b) a ## b
 #define SUFFIX(a,b) SUFFIX2(a,b)


### PR DESCRIPTION
GCC 10 defaults to `--no-common`. There are linking errors because of it.  
More info at [Porting to GCC 10](https://gcc.gnu.org/gcc-10/porting_to.html)

Not sure if i put `extern` in right places though. Seems it works