### PR TITLE
Make MTProxy compatible with non-glibc systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ifeq ($m, 64)
 ARCH = -m64
 endif
 
-CFLAGS = $(ARCH) -O3 -std=gnu11 -Wall -mpclmul -march=core2 -mfpmath=sse -mssse3 -fno-strict-aliasing -fno-strict-overflow -fwrapv -DAES=1 -DCOMMIT=\"${COMMIT}\" -D_GNU_SOURCE=1 -D_FILE_OFFSET_BITS=64
+CFLAGS = $(ARCH) -O3 -std=gnu11 -Wall -mpclmul -march=core2 -mfpmath=sse -mssse3 -fcommon -fno-strict-aliasing -fno-strict-overflow -fwrapv -DAES=1 -DCOMMIT=\"${COMMIT}\" -D_GNU_SOURCE=1 -D_FILE_OFFSET_BITS=64
 LDFLAGS = $(ARCH) -ggdb -rdynamic -lm -lrt -lcrypto -lz -lpthread -lcrypto
 
 LIB = ${OBJ}/lib

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,11 @@ ARCH = -m64
 endif
 
 CFLAGS = $(ARCH) -O3 -std=gnu11 -Wall -mpclmul -march=core2 -mfpmath=sse -mssse3 -fcommon -fno-strict-aliasing -fno-strict-overflow -fwrapv -DAES=1 -DCOMMIT=\"${COMMIT}\" -D_GNU_SOURCE=1 -D_FILE_OFFSET_BITS=64
-LDFLAGS = $(ARCH) -ggdb -rdynamic -lm -lrt -lcrypto -lz -lpthread -lcrypto
+LDFLAGS = $(ARCH) -ggdb -rdynamic -lm -lrt -lz -lpthread -lcrypto
+LIBEXECTEST = '\#include <execinfo.h>\nint main(){return backtrace(0,0);}'
+ifeq ($(shell printf ${LIBEXECTEST} | gcc -x c -o /dev/null - -lexecinfo 2>/dev/null; echo $$?), 0)
+LDFLAGS := ${LDFLAGS} -lexecinfo # For systems without glibc e.g. Alpine linux that uses musl libc.
+endif
 
 LIB = ${OBJ}/lib
 CINCLUDE = -iquote common -iquote .

--- a/jobs/jobs.c
+++ b/jobs/jobs.c
@@ -370,9 +370,7 @@ __thread job_t this_job;
 
 long int lrand48_j (void) {
   if (this_job_thread) {
-    long int t;
-    lrand48_r (&this_job_thread->rand_data, &t);
-    return t;
+    return nrand48 (this_job_thread->rand_data);
   } else {
     return lrand48 ();
   }
@@ -380,9 +378,7 @@ long int lrand48_j (void) {
 
 long int mrand48_j (void) {
   if (this_job_thread) {
-    long int t;
-    mrand48_r (&this_job_thread->rand_data, &t);
-    return t;
+    return jrand48 (this_job_thread->rand_data);
   } else {
     return mrand48 ();
   }
@@ -390,9 +386,7 @@ long int mrand48_j (void) {
 
 double drand48_j (void) {
   if (this_job_thread) {
-    double t;
-    drand48_r (&this_job_thread->rand_data, &t);
-    return t;
+    return erand48 (this_job_thread->rand_data);
   } else {
     return drand48 ();
   }
@@ -463,8 +457,10 @@ int create_job_thread_ex (int thread_class, void *(*thread_work)(void *)) {
   JT->id = i;
   assert (JT->job_queue);
 
-  srand48_r (rdtsc () ^ lrand48 (), &JT->rand_data);
-
+  long int seed = rdtsc () ^ lrand48 ();
+  JT->rand_data[0] = 0x330e;
+  JT->rand_data[1] = seed;
+  JT->rand_data[2] = seed >> 16;
 
   if (thread_class != JC_MAIN) {
     pthread_attr_t attr;

--- a/jobs/jobs.h
+++ b/jobs/jobs.h
@@ -231,7 +231,7 @@ struct job_thread {
   long long jobs_created;
   long long jobs_active;
   int thread_system_id;
-  struct drand48_data rand_data;
+  unsigned short rand_data[3];
   job_t timer_manager;
   double wakeup_time;
   struct job_class *job_class;


### PR DESCRIPTION
MTProxy relies on some specific glibc features that not every libc supports. So if one wants to compile it on Alpine Linux some tweaks are required. I successfully compiled MTProxy with musl libc by doing the following:

- `backtrace` function is non-standard. Use `libexecinfo` port if it's available in the system.
- Change `lrand48_r`, `mrand48_r`, `drand48_r`, `rand48_r` to their standard counterparts.
- Add `-fcommon` option to fix the build on the latest GCC versions.