### PR TITLE
Add compatibility for non-glibc (e.g. musl) builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ifeq ($m, 64)
 ARCH = -m64
 endif
 
-CFLAGS = $(ARCH) -O3 -std=gnu11 -Wall -Wno-array-bounds -mpclmul -march=core2 -mfpmath=sse -mssse3 -fno-strict-aliasing -fno-strict-overflow -fwrapv -DAES=1 -DCOMMIT=\"${COMMIT}\" -D_GNU_SOURCE=1 -D_FILE_OFFSET_BITS=64
+CFLAGS = $(ARCH) -O3 -std=gnu11 -Wall -Wextra -Wno-unused-parameter -Wno-error=array-bounds -Wno-error=incompatible-pointer-types -mpclmul -march=core2 -mfpmath=sse -mssse3 -fno-strict-aliasing -fno-strict-overflow -fwrapv -DAES=1 -DCOMMIT=\"${COMMIT}\" -D_GNU_SOURCE=1 -D_FILE_OFFSET_BITS=64
 LDFLAGS = $(ARCH) -ggdb -rdynamic -lm -lrt -lcrypto -lz -lpthread -lcrypto
 
 LIB = ${OBJ}/lib
@@ -40,6 +40,7 @@ DEPENDENCE_STRANGE	:=	$(subst ${OBJ}/,${DEP}/,$(patsubst %.o,%.d,${OBJECTS_STRAN
 DEPENDENCE_NORM	:=	$(subst ${OBJ}/,${DEP}/,$(patsubst %.o,%.d,${OBJECTS}))
 
 LIB_OBJS_NORMAL := \
+	${OBJ}/common/drand48-compat.o \
 	${OBJ}/common/crc32c.o \
 	${OBJ}/common/pid.o \
 	${OBJ}/common/sha1.o \

--- a/common/drand48-compat.c
+++ b/common/drand48-compat.c
@@ -1,0 +1,150 @@
+#include "drand48-compat.h"
+#include <string.h>   /* memset */
+#include <math.h>     /* ldexp */
+
+#ifndef __GLIBC__
+
+/* glibc-compatible constants */
+#define DR48_A   0x5deece66dULL
+#define DR48_C   0x00000000bULL
+#define DR48_MASK ((1ULL << 48) - 1ULL)
+
+static inline uint64_t pack48(const unsigned short x[3]) {
+  return ((uint64_t)x[0])
+       | ((uint64_t)x[1] << 16)
+       | ((uint64_t)x[2] << 32);
+}
+
+static inline void unpack48(uint64_t v, unsigned short x[3]) {
+  x[0] = (unsigned short)(v & 0xFFFFu);
+  x[1] = (unsigned short)((v >> 16) & 0xFFFFu);
+  x[2] = (unsigned short)((v >> 32) & 0xFFFFu);
+}
+
+static inline void ensure_init(struct drand48_data *b) {
+  if (b-> __init)
+    return;
+
+  /* Allow "zero-filled struct" init, as man page suggests. */
+  b->__x[0] = 0x330e;
+  b->__x[1] = 0;
+  b->__x[2] = 0;
+  b->__a = DR48_A;
+  b->__c = (unsigned short)DR48_C;
+  b->__init = 1;
+}
+
+static inline void iterate(unsigned short xsubi[3], struct drand48_data *b) {
+  uint64_t x = pack48(xsubi);
+  /* (a*x + c) mod 2^48 */
+  x = (b->__a * x + (uint64_t)b->__c) & DR48_MASK;
+  unpack48(x, xsubi);
+}
+
+int srand48_r(long int seedval, struct drand48_data *buffer) {
+  /* Standards say seedval is effectively 32-bit. */
+  if (sizeof(long int) > 4)
+    seedval &= 0xffffffffL;
+
+  buffer->__x[2] = (unsigned short)((uint32_t)seedval >> 16);
+  buffer->__x[1] = (unsigned short)((uint32_t)seedval & 0xFFFFu);
+  buffer->__x[0] = 0x330e;
+
+  buffer->__a = DR48_A;
+  buffer->__c = (unsigned short)DR48_C;
+  buffer->__init = 1;
+  return 0;
+}
+
+int seed48_r(unsigned short int seed16v[3], struct drand48_data *buffer) {
+  ensure_init(buffer);
+
+  buffer->__old_x[0] = buffer->__x[0];
+  buffer->__old_x[1] = buffer->__x[1];
+  buffer->__old_x[2] = buffer->__x[2];
+
+  buffer->__x[0] = seed16v[0];
+  buffer->__x[1] = seed16v[1];
+  buffer->__x[2] = seed16v[2];
+
+  buffer->__a = DR48_A;
+  buffer->__c = (unsigned short)DR48_C;
+  buffer->__init = 1;
+  return 0;
+}
+
+/* param[0..2] = X, param[3..5] = A, param[6] = C */
+int lcong48_r(unsigned short int param[7], struct drand48_data *buffer) {
+  buffer->__x[0] = param[0];
+  buffer->__x[1] = param[1];
+  buffer->__x[2] = param[2];
+
+  buffer->__a = ((unsigned long long)param[3])
+              | ((unsigned long long)param[4] << 16)
+              | ((unsigned long long)param[5] << 32);
+
+  buffer->__c = param[6];
+  buffer->__init = 1;
+  return 0;
+}
+
+int drand48_r(struct drand48_data *buffer, double *result) {
+  ensure_init(buffer);
+  iterate(buffer->__x, buffer);
+
+  uint64_t x = pack48(buffer->__x);
+  /* x in [0, 2^48); convert to [0.0, 1.0) */
+  *result = ldexp((double)x, -48);
+  return 0;
+}
+
+int erand48_r(unsigned short int xsubi[3], struct drand48_data *buffer, double *result) {
+  ensure_init(buffer);
+  iterate(xsubi, buffer);
+
+  uint64_t x = pack48(xsubi);
+  *result = ldexp((double)x, -48);
+  return 0;
+}
+
+int lrand48_r(struct drand48_data *buffer, long int *result) {
+  ensure_init(buffer);
+  iterate(buffer->__x, buffer);
+
+  uint64_t x = pack48(buffer->__x);
+  /* non-negative in [0, 2^31) */
+  *result = (long int)(x >> 17);
+  return 0;
+}
+
+int nrand48_r(unsigned short int xsubi[3], struct drand48_data *buffer, long int *result) {
+  ensure_init(buffer);
+  iterate(xsubi, buffer);
+
+  uint64_t x = pack48(xsubi);
+  *result = (long int)(x >> 17);
+  return 0;
+}
+
+int mrand48_r(struct drand48_data *buffer, long int *result) {
+  ensure_init(buffer);
+  iterate(buffer->__x, buffer);
+
+  uint64_t x = pack48(buffer->__x);
+  /* signed in [-2^31, 2^31) */
+  int32_t v = (int32_t)(x >> 16);
+  *result = (long int)v;
+  return 0;
+}
+
+int jrand48_r(unsigned short int xsubi[3], struct drand48_data *buffer, long int *result) {
+  ensure_init(buffer);
+  iterate(xsubi, buffer);
+
+  uint64_t x = pack48(xsubi);
+  int32_t v = (int32_t)(x >> 16);
+  *result = (long int)v;
+  return 0;
+}
+
+#endif

--- a/common/drand48-compat.h
+++ b/common/drand48-compat.h
@@ -1,0 +1,45 @@
+#pragma once
+
+/*
+  Drop-in drand48_r compat for non-glibc libcs (e.g., musl).
+  Provides:
+    struct drand48_data
+    srand48_r, seed48_r, lcong48_r
+    drand48_r, erand48_r
+    lrand48_r, nrand48_r
+    mrand48_r, jrand48_r
+
+  Compile this ONLY when your libc doesn't provide these symbols,
+  otherwise you'll get duplicate symbol errors.
+*/
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct drand48_data {
+  unsigned short int __x[3];      /* Current state. */
+  unsigned short int __old_x[3];  /* Old state. */
+  unsigned short int __c;         /* Additive const. */
+  unsigned short int __init;      /* Init flag. */
+  unsigned long long int __a;     /* Factor. */
+};
+
+int srand48_r(long int seedval, struct drand48_data *buffer);
+int seed48_r(unsigned short int seed16v[3], struct drand48_data *buffer);
+int lcong48_r(unsigned short int param[7], struct drand48_data *buffer);
+
+int drand48_r(struct drand48_data *buffer, double *result);
+int erand48_r(unsigned short int xsubi[3], struct drand48_data *buffer, double *result);
+
+int lrand48_r(struct drand48_data *buffer, long int *result);
+int nrand48_r(unsigned short int xsubi[3], struct drand48_data *buffer, long int *result);
+
+int mrand48_r(struct drand48_data *buffer, long int *result);
+int jrand48_r(unsigned short int xsubi[3], struct drand48_data *buffer, long int *result);
+
+#ifdef __cplusplus
+}
+#endif

--- a/common/server-functions.c
+++ b/common/server-functions.c
@@ -35,7 +35,9 @@
 #include <arpa/inet.h>
 #include <assert.h>
 #include <errno.h>
+#ifdef __GLIBC__
 #include <execinfo.h>
+#endif
 #include <fcntl.h>
 #include <getopt.h>
 #include <grp.h>
@@ -168,6 +170,7 @@ const char *get_version_string (void) {
 }
 
 void print_backtrace (void) {
+#ifdef __GLIBC__
   void *buffer[64];
   int nptrs = backtrace (buffer, 64);
   kwrite (2, "\n------- Stack Backtrace -------\n", 33);
@@ -178,6 +181,9 @@ void print_backtrace (void) {
     kwrite (2, s, strlen (s));
     kwrite (2, "\n", 1);
   }
+#else
+  kwrite(2, "--- Backtrace Only On Glibc ---\n", 32);
+#endif
 }
 
 pthread_t debug_main_pthread_id;

--- a/jobs/jobs.h
+++ b/jobs/jobs.h
@@ -25,6 +25,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include <semaphore.h>
+
+#ifndef __GLIBC__
+#include "common/drand48-compat.h"
+#endif
+
 #include "net/net-events.h"
 #include "net/net-msg.h"
 #include "net/net-timers.h"


### PR DESCRIPTION
The current implementation of MTProxy relies on glibc's `drand48` and `execinfo` which are absent on musl.

Adding a drop-in replacement for drand48 and avoiding execinfo allows to build MTProxy for Alpine-based docker image.

Proposing my solution to the community.