### PR TITLE
fix: support pid > 65535

### DIFF
--- a/common/pid.c
+++ b/common/pid.c
@@ -39,8 +39,7 @@ npid_t PID;
 void init_common_PID (void) {
   if (!PID.pid) {
     int p = getpid ();
-    assert (!(p & 0xffff0000));
-    PID.pid = p;
+    PID.pid = (unsigned short) (p & 0xffff);
   }
   if (!PID.utime) {
     PID.utime = time (0);


### PR DESCRIPTION
  ## Problem
  MTProxy crashed due to `assert (!(p & 0xffff0000))` in `init_common_PID`: the code assumed PID always fits in 16 bits. On systems with `pid_max` > 65535 (e.g. pid 94936, 95241), the assert triggered
  and the proxy crashed.
  ## Solution (workaround)
  Removed the assert and store only the lower 16 bits of the PID instead of the full value:

  PID.pid = (unsigned short) (p & 0xffff);

  ## Why not 32 bits
  This is a workaround. Ideally we would pass a 32-bit pid, but that is **not possible**:
  - `process_id` is serialized in the RPC handshake between MTProxy and Telegram DC servers
  - The packet format is fixed: 32 bytes, pid is 16 bits
  - We cannot change Telegram servers or the protocol
  - With a 32-bit pid, the handshake size grows from 32 to 40 bytes — DC expects 32, so the protocol breaks
  So we only have truncation: instead of a crash, there may be pid collisions when pid > 65535 (rarely critical for MTProxy).